### PR TITLE
Fix adding coauthor with special chars in nicename

### DIFF
--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -98,7 +98,7 @@ jQuery(document).ready(function () {
 		co.bind('blur', coauthors_stop_editing);
 		
 		// Set the value for the auto-suggest box to the Author's name and hide it
-		co.val(unescape(author.name))
+		co.val(decodeURIComponent(author.name))
 			.hide()
 			.unbind('focus')
 			;
@@ -194,7 +194,7 @@ jQuery(document).ready(function () {
 			;
 		
 		if(authorName)
-			$co.attr( 'value', unescape( authorName ) );
+			$co.attr( 'value', decodeURIComponent( authorName ) );
 		else
 			$co.attr( 'value', coAuthorsPlusStrings.search_box_text )
 				.focus( function(){ $co.val( '' ) } )
@@ -258,7 +258,7 @@ jQuery(document).ready(function () {
 	function coauthors_create_author_tag(author) {
 		
 		var $tag = jQuery('<span></span>')
-							.html(unescape(author.name))
+							.html(decodeURIComponent(author.name))
 							.attr('title', coAuthorsPlusStrings.input_box_title)
 							.addClass('coauthor-tag')
 							// Add Click event to edit
@@ -305,7 +305,7 @@ jQuery(document).ready(function () {
 							'type': 'hidden',
 							'id': 'coauthors_hidden_input',
 							'name': 'coauthors[]',
-							'value': unescape(author.nicename)
+							'value': decodeURIComponent(author.nicename)
 							})
 						;
 		

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -798,7 +798,7 @@ class CoAuthors_Guest_Authors
 				break;
 			case 'user_nicename':
 			case 'post_name':
-				$value = $this->get_post_meta_key( $value );
+				$value = $value = sanitize_title( $this->get_post_meta_key( $value ) );
 				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_name=%s AND post_type = %s", $value, $this->post_type );
 				$post_id = $wpdb->get_var( $query );
 				if ( empty( $post_id ) ) {

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -798,7 +798,7 @@ class CoAuthors_Guest_Authors
 				break;
 			case 'user_nicename':
 			case 'post_name':
-				$value = $value = sanitize_title( $this->get_post_meta_key( $value ) );
+				$value = sanitize_title( $this->get_post_meta_key( $value ) );
 				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_name=%s AND post_type = %s", $value, $this->post_type );
 				$post_id = $wpdb->get_var( $query );
 				if ( empty( $post_id ) ) {


### PR DESCRIPTION
Any arabic, hebrew etc. characters in the co-author's nicename will cause bugs whereby the co-author cannot be added to a post.
- Switches use of js depricated unescape (which causes encoding issues) to decodeURIComponent
- Calls sanitize title on $value when calling `get_guest_author_by( 'user_nicename', $value )`. This ensures we are selecting for the same value stored in post_name
